### PR TITLE
Convert image from URL

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -33,9 +33,11 @@ export class ImageRequest {
 
       let imageRequestInfo: ImageRequestInfo = <ImageRequestInfo>{};
       imageRequestInfo.requestType = this.parseRequestType(event);
+      imageRequestInfo.key = this.parseImageKey(event, imageRequestInfo.requestType);
+      imageRequestInfo.edits = this.parseImageEdits(event, imageRequestInfo.requestType);
 
       let originalImage: OriginalImageInfo;
-      imageRequestInfo.imageUrl = this.parseImageUrl(event);
+      imageRequestInfo.imageUrl = imageRequestInfo.requestType === RequestTypes.DEFAULT ? this.parseImageUrl(event) : null;
       
       if (!imageRequestInfo.imageUrl) {
         imageRequestInfo.bucket = this.parseImageBucket(event, imageRequestInfo.requestType);
@@ -44,11 +46,7 @@ export class ImageRequest {
         originalImage = await this.getOriginalImageFromUrl(imageRequestInfo.imageUrl, imageRequestInfo.key);
       }
 
-      imageRequestInfo.key = this.parseImageKey(event, imageRequestInfo.requestType);
-      imageRequestInfo.edits = this.parseImageEdits(event, imageRequestInfo.requestType);
-
       imageRequestInfo = { ...imageRequestInfo, ...originalImage };
-
       imageRequestInfo.headers = this.parseImageHeaders(event, imageRequestInfo.requestType);
 
       // If the original image is SVG file and it has any edits but no output format, change the format to WebP.
@@ -138,7 +136,6 @@ export class ImageRequest {
     }
 
     result.cacheControl = originalImage.CacheControl ?? 'max-age=31536000,public';
-    result.cacheControl = 'max-age=31536000,public';
     result.originalImage = imageBuffer;
 
     return result;
@@ -182,17 +179,17 @@ export class ImageRequest {
 
   parseImageUrl(event: ImageHandlerEvent): string | null {
     // Decode the image request
-    const { imageUrl } = this.decodeRequest(event);
+    const decoded = this.decodeRequest(event);
 
-    if (imageUrl && !this.isValidUrl(imageUrl)) {
+    if (decoded?.imageUrl && !this.isValidUrl(decoded.imageUrl)) {
       throw new ImageHandlerError(
         StatusCodes.BAD_REQUEST,
         'ImageUrl::InvalidUrl',
-        `${imageUrl} is not a valid URL.`
+        `${decoded.imageUrl} is not a valid URL.`
       );
     }
 
-    return imageUrl;
+    return decoded?.imageUrl;
   }
 
 

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -152,15 +152,15 @@ export class ImageRequest {
 
   /**
    * Gets the original image from an Amazon S3 bucket.
-   * @param imageUrl The image URL //The name of the bucket containing the image.
+   * @param imageUrl The image URL
    * @param key The key name corresponding to the image.
    * @returns The original image or an error.
    */
   public async getOriginalImageFromUrl(imageUrl: string, key: string): Promise<OriginalImageInfo> {
     try {
       const result: OriginalImageInfo = {};
-      const originalImage = await axios.get(imageUrl, {responseType: 'arraybuffer'}) as Uint8Array;
-      const imageBuffer = Buffer.from(originalImage);
+      const originalImage = await axios.get(imageUrl, {responseType: 'arraybuffer'});
+      const imageBuffer = Buffer.from(originalImage.data as Uint8Array);
       result.contentType = 'image';
       result.cacheControl = 'max-age=31536000,public';
       result.originalImage = imageBuffer;

--- a/source/image-handler/lib/interfaces.ts
+++ b/source/image-handler/lib/interfaces.ts
@@ -19,6 +19,7 @@ export interface ImageHandlerEvent {
 
 export interface DefaultImageRequest {
   bucket?: string;
+  imageUrl: string;
   key: string;
   edits?: ImageEdits;
   outputFormat?: ImageFormatTypes;
@@ -40,7 +41,8 @@ export interface BoxSize {
 
 export interface ImageRequestInfo {
   requestType: RequestTypes;
-  bucket: string;
+  bucket?: string;
+  imageUrl: string;
   key: string;
   edits?: ImageEdits;
   originalImage: Buffer;

--- a/source/image-handler/lib/interfaces.ts
+++ b/source/image-handler/lib/interfaces.ts
@@ -19,7 +19,7 @@ export interface ImageHandlerEvent {
 
 export interface DefaultImageRequest {
   bucket?: string;
-  imageUrl: string;
+  imageUrl?: string;
   key: string;
   edits?: ImageEdits;
   outputFormat?: ImageFormatTypes;

--- a/source/image-handler/lib/interfaces.ts
+++ b/source/image-handler/lib/interfaces.ts
@@ -42,7 +42,7 @@ export interface BoxSize {
 export interface ImageRequestInfo {
   requestType: RequestTypes;
   bucket?: string;
-  imageUrl: string;
+  imageUrl?: string;
   key: string;
   edits?: ImageEdits;
   originalImage: Buffer;

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -19,6 +19,7 @@
     "test": "jest --coverage --silent"
   },
   "dependencies": {
+    "axios": "^0.27.2",
     "color": "3.1.3",
     "color-name": "1.1.4",
     "sharp": "^0.27.0"

--- a/source/image-handler/test/image-handler.spec.ts
+++ b/source/image-handler/test/image-handler.spec.ts
@@ -27,6 +27,7 @@ describe('process()', () => {
     it('Should pass if the output image is different from the input image with edits applied', async () => {
       // Arrange
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'sample-image-001.jpg',
@@ -50,6 +51,7 @@ describe('process()', () => {
     it('Should pass if the output image is in a different format than the original image', async () => {
       // Arrange
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'sample-image-001.jpg',
@@ -71,6 +73,7 @@ describe('process()', () => {
     it('Should pass if the output image is webp format and reductionEffort is provided', async () => {
       // Arrange
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'sample-image-001.jpg',
@@ -93,6 +96,7 @@ describe('process()', () => {
     it('Should pass if no edits are specified and the original image is returned', async () => {
       // Arrange
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'sample-image-001.jpg',
@@ -112,6 +116,7 @@ describe('process()', () => {
     it('Should fail the return payload is larger than 6MB', async () => {
       // Arrange
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'sample-image-001.jpg',
@@ -138,6 +143,7 @@ describe('process()', () => {
       // Arrange
       const originalImage = fs.readFileSync('./test/image/1x1.jpg');
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'test.jpg',
@@ -164,6 +170,7 @@ describe('process()', () => {
       // Arrange
       const originalImage = fs.readFileSync('./test/image/1x1.jpg');
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'test.jpg',
@@ -192,6 +199,7 @@ describe('process()', () => {
     it('Should pass if the original image does not have orientation', async () => {
       // Arrange
       const request: ImageRequestInfo = {
+        imageUrl: 'https://image.url/img-png',
         requestType: RequestTypes.DEFAULT,
         bucket: 'sample-bucket',
         key: 'test.jpg',

--- a/source/image-handler/test/image-request.spec.ts
+++ b/source/image-handler/test/image-request.spec.ts
@@ -157,6 +157,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: 'Thumbor',
         bucket: 'allowedBucket001',
+        imageUrl: null,
         key: 'test-image-001.jpg',
         edits: { grayscale: true },
         originalImage: Buffer.from('SampleImageContent\n'),
@@ -204,6 +205,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: 'Thumbor',
         bucket: 'allowedBucket001',
+        imageUrl: null,
         key: 'test-image-001.jpg',
         edits: {
           toFormat: 'png',
@@ -267,6 +269,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: RequestTypes.CUSTOM,
         bucket: 'allowedBucket001',
+        imageUrl: null,
         key: 'custom-image.jpg',
         edits: {
           grayscale: true,
@@ -314,6 +317,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: RequestTypes.CUSTOM,
         bucket: 'allowedBucket001',
+        imageUrl: null,
         key: 'custom-image',
         edits: {
           grayscale: true,
@@ -584,6 +588,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: 'Thumbor',
         bucket: 'validBucket',
+        imageUrl: null,
         key: 'image.svg',
         edits: {},
         originalImage: Buffer.from('SampleImageContent\n'),
@@ -618,6 +623,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: 'Thumbor',
         bucket: 'validBucket',
+        imageUrl: null,
         key: 'image.svg',
         edits: { resize: { width: 100, height: 100 } },
         outputFormat: 'png',
@@ -653,6 +659,7 @@ describe('setup()', () => {
       const expectedResult = {
         requestType: 'Thumbor',
         bucket: 'validBucket',
+        imageUrl: null,
         key: 'image.svg',
         edits: { toFormat: 'jpeg' },
         outputFormat: 'jpeg',


### PR DESCRIPTION
**Description of changes:**
Added functionality to convert image from a supplied URL.

Example:
```
{
  "imageUrl": "https://url.to/image.jpg",
  "edits": {
    "resize": {
      "width": 500,
      "height": 500,
      "fit": "cover"
    }
  }
}
```

`bucket` and  `key` can be omitted - they are only relevant if converting an image stored on S3.

**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
